### PR TITLE
Removes nested tokio::current_thread executor from within the Pennsieve struct

### DIFF
--- a/src/ps/api/client/mod.rs
+++ b/src/ps/api/client/mod.rs
@@ -16,7 +16,7 @@ use hyper::header::{HeaderName, HeaderValue};
 use hyper::{self, Method, StatusCode};
 use hyper_tls::HttpsConnector;
 use lazy_static::lazy_static;
-use log::{debug, error, warn};
+use log::{debug, error};
 use rusoto_cognito_idp::{CognitoIdentityProvider, InitiateAuthRequest};
 use rusoto_core::credential::{AwsCredentials, StaticProvider};
 use rusoto_core::request::HttpClient;
@@ -551,15 +551,6 @@ impl Pennsieve {
         api_key: S,
         api_secret: S,
     ) -> Future<response::ApiSession> {
-        // TODO(jesse) GET RID OF THIS INNER EXECUTOR AND RETURN THE FUTURE LIKE A NORMAL PERSON WOULD
-        warn!("Spawning new `current_thread` executor, this function should not create its own executor.");
-
-        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-
-        let config_response: serde_json::Value = runtime
-            .block_on(get!(self, "/authentication/cognito-config"))
-            .unwrap();
-
         let cognito = rusoto_cognito_idp::CognitoIdentityProviderClient::new_with(
             HttpClient::new().expect("failed to create request dispatcher"),
             StaticProvider::from(AwsCredentials::default()),
@@ -570,55 +561,62 @@ impl Pennsieve {
         auth_parameters.insert("USERNAME".to_string(), api_key.into());
         auth_parameters.insert("PASSWORD".to_string(), api_secret.into());
 
-        let request = InitiateAuthRequest {
-            analytics_metadata: None,
-            auth_flow: "USER_PASSWORD_AUTH".to_string(),
-            auth_parameters: Some(auth_parameters),
-            client_id: config_response["tokenPool"]["appClientId"]
-                .as_str()
-                .unwrap()
-                .to_string(),
-            client_metadata: None,
-            user_context_data: None,
-        };
+        let this = self.clone();
 
-        match runtime.block_on(cognito.initiate_auth(request)) {
-            Ok(response) => {
-                let id_token = response
-                    .clone()
-                    .authentication_result
-                    .unwrap()
-                    .id_token
-                    .unwrap();
+        into_future_trait(get!(self, "/authentication/cognito-config").and_then(
+            move |config_response: serde_json::Value| {
+                let request = InitiateAuthRequest {
+                    analytics_metadata: None,
+                    auth_flow: "USER_PASSWORD_AUTH".to_string(),
+                    auth_parameters: Some(auth_parameters),
+                    client_id: config_response["tokenPool"]["appClientId"]
+                        .as_str()
+                        .unwrap()
+                        .to_string(),
+                    client_metadata: None,
+                    user_context_data: None,
+                };
+                cognito
+                    .initiate_auth(request)
+                    .and_then(move |response| {
+                        let id_token = response
+                            .clone()
+                            .authentication_result
+                            .unwrap()
+                            .id_token
+                            .unwrap();
 
-                let id_token_string = id_token.to_string();
-                let payload_parts: Vec<&str> = id_token_string.split(".").collect();
-                let payload_b64 = base64_url::decode(payload_parts[1]).unwrap();
-                let payload_str = std::str::from_utf8(&payload_b64).unwrap();
-                let payload: serde_json::Value = serde_json::from_str(payload_str).unwrap();
-                let organization_node_id = payload["custom:organization_node_id"].as_str().unwrap();
+                        let id_token_string = id_token.to_string();
+                        let payload_parts: Vec<&str> = id_token_string.split(".").collect();
+                        let payload_b64 = base64_url::decode(payload_parts[1]).unwrap();
+                        let payload_str = std::str::from_utf8(&payload_b64).unwrap();
+                        let payload: serde_json::Value = serde_json::from_str(payload_str).unwrap();
+                        let organization_node_id =
+                            payload["custom:organization_node_id"].as_str().unwrap();
 
-                self.set_current_organization(Some(&OrganizationId::new(organization_node_id)));
+                        this.set_current_organization(Some(&OrganizationId::new(
+                            organization_node_id,
+                        )));
 
-                let access_token = response
-                    .clone()
-                    .authentication_result
-                    .unwrap()
-                    .access_token
-                    .unwrap();
+                        let access_token = response
+                            .clone()
+                            .authentication_result
+                            .unwrap()
+                            .access_token
+                            .unwrap();
 
-                let session_token = SessionToken::new(access_token);
-                self.inner.lock().unwrap().session_token = Some(session_token.clone());
+                        let session_token = SessionToken::new(access_token);
+                        this.set_session_token(Some(session_token.clone()));
 
-                into_future_trait(futures::finished(response::ApiSession::new(
-                    session_token,
-                    organization_node_id.to_string(),
-                    payload["exp"].as_i64().unwrap() as i32,
-                )))
-            }
-
-            Err(err) => into_future_trait(futures::failed(err.into())),
-        }
+                        into_future_trait(future::ok(response::ApiSession::new(
+                            session_token,
+                            organization_node_id.to_string(),
+                            payload["exp"].as_i64().unwrap() as i32,
+                        )))
+                    })
+                    .map_err(Into::into)
+            },
+        ))
     }
 
     /// Get the current user.


### PR DESCRIPTION
This removes the use of a nested `tokio::runtime::current_thread::Runtime` + `block_on` by rolling up futures into a single chain.