### PR TITLE
Cleanup login

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Pennsieve <https://github.com/Pennsieve/pennsieve-rust>"]
 publish = false
 edition = "2018"
 
+[features]
+mocks = []
+
 [dependencies]
 base64-url = "1.4.9"
 chrono = { version = "^0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ serde_derive = "^1.0"
 serde_json = "^1.0"
 tokio = "^0.1"
 url = "^2.1"
+
+[dev-dependencies]
+mockito = "0.30.0"

--- a/src/ps/api/client/mod.rs
+++ b/src/ps/api/client/mod.rs
@@ -611,33 +611,75 @@ impl Pennsieve {
                 Either::B(
                     cognito
                         .initiate_auth(request)
+                        .map_err(Into::into)
                         .and_then(move |response| {
-                            let id_token = response
-                                .clone()
-                                .authentication_result
-                                .unwrap()
-                                .id_token
-                                .unwrap();
+                            let authentication_result = match response.clone().authentication_result {
+                                Some(value) => value,
+                                None => return into_future_trait(futures::failed(crate::ps::Error::initiate_auth_error(
+                                    "No authentication result, does another challenge need to be passed?"
+                                )))
+                            };
+
+                            let access_token = match authentication_result.access_token {
+                                Some(string) => string,
+                                None => return into_future_trait(futures::failed(crate::ps::Error::initiate_auth_error(
+                                    "No access token in the Cognito initiate auth response."
+                                )))
+                            };
+
+                            let id_token = match authentication_result.id_token {
+                                Some(string) => string,
+                                None => return into_future_trait(futures::failed(crate::ps::Error::initiate_auth_error(
+                                    "No ID token in the Cognito initiate auth response."
+                                )))
+                            };
 
                             let id_token_string = id_token.to_string();
                             let payload_parts: Vec<&str> = id_token_string.split(".").collect();
-                            let payload_b64 = base64_url::decode(payload_parts[1]).unwrap();
-                            let payload_str = std::str::from_utf8(&payload_b64).unwrap();
-                            let payload: serde_json::Value =
-                                serde_json::from_str(payload_str).unwrap();
-                            let organization_node_id =
-                                payload["custom:organization_node_id"].as_str().unwrap();
+
+                            let payload_b64 = match base64_url::decode(payload_parts[1]) {
+                                Ok(b64) => b64,
+                                Err(error) => return into_future_trait(futures::failed(error.into()))
+                            };
+
+                            let payload_str = match std::str::from_utf8(&payload_b64) {
+                                Ok(str) => str,
+                                Err(error) => return into_future_trait(futures::failed(
+                                    crate::ps::Error::initiate_auth_error(format!("Cognito response payload is not UTF-8. Reason: {}", error.to_string()))
+                                ))
+                            };
+
+                            let payload: serde_json::Value = match serde_json::from_str(payload_str) {
+                                Ok(value) => value,
+                                Err(error) => return into_future_trait(futures::failed(
+                                    crate::ps::Error::initiate_auth_error(format!("Cognito response payload is not json. Reason: {}", error.to_string()))
+                                ))
+                            };
+
+                            let organization_node_id_value = match payload.get("custom:organization_node_id") {
+                                Some(value) => value,
+                                None => return into_future_trait(futures::failed(
+                                    crate::ps::Error::initiate_auth_error("Cognito response payload does not have the `custom:organization_node_id` property")
+                                ))
+                            };
+
+                            let organization_node_id = match organization_node_id_value.as_str() {
+                                Some(str) => str,
+                                None => return into_future_trait(futures::failed(
+                                    crate::ps::Error::initiate_auth_error("Cognito response payload `custom:organization_node_id` is not a string.")
+                                ))
+                            };
+
+                            let exp = match payload["exp"].as_i64() {
+                                Some(i64) => i64,
+                                None => return into_future_trait(futures::failed(
+                                    crate::ps::Error::initiate_auth_error("Cognito response payload does not have an expiration date `exp`.")
+                                ))
+                            } as i32;
 
                             this.set_current_organization(Some(&OrganizationId::new(
                                 organization_node_id,
                             )));
-
-                            let access_token = response
-                                .clone()
-                                .authentication_result
-                                .unwrap()
-                                .access_token
-                                .unwrap();
 
                             let session_token = SessionToken::new(access_token);
                             this.set_session_token(Some(session_token.clone()));
@@ -645,10 +687,9 @@ impl Pennsieve {
                             into_future_trait(future::ok(response::ApiSession::new(
                                 session_token,
                                 organization_node_id.to_string(),
-                                payload["exp"].as_i64().unwrap() as i32,
+                                exp
                             )))
-                        })
-                        .map_err(Into::into),
+                        }),
                 )
             },
         ))

--- a/src/ps/api/client/mod.rs
+++ b/src/ps/api/client/mod.rs
@@ -607,7 +607,7 @@ impl Pennsieve {
 
                     let access_token = authentication_result.access_token
                         .ok_or(crate::ps::Error::initiate_auth_error("No access token in the Cognito initiate auth response."))?;
-                    
+
                     let id_token = authentication_result.id_token
                         .ok_or(crate::ps::Error::initiate_auth_error(
                             "No ID token in the Cognito initiate auth response."
@@ -615,9 +615,9 @@ impl Pennsieve {
 
                     let payload_parts: Vec<&str> = id_token.split(".").collect();
                     let payload_b64 = base64_url::decode(payload_parts[1])?;
-                    let payload_str = std::str::from_utf8(&payload_b64).map_err(|err| 
+                    let payload_str = std::str::from_utf8(&payload_b64).map_err(|err| {
                         crate::ps::Error::initiate_auth_error(err.to_string())
-                    )?;
+                    })?;
                     let payload: serde_json::Value = serde_json::from_str(payload_str)?;
 
                     let organization_node_id_value = payload.get("custom:organization_node_id")
@@ -625,7 +625,6 @@ impl Pennsieve {
 
                     let organization_node_id = organization_node_id_value.as_str()
                         .ok_or(crate::ps::Error::initiate_auth_error("Cognito response payload `custom:organization_node_id` is not a string."))?;
-                    
                     let exp = payload["exp"].as_i64()
                         .ok_or(crate::ps::Error::initiate_auth_error("Cognito response payload does not have an expiration date `exp`."))?;
 

--- a/src/ps/api/client/mod.rs
+++ b/src/ps/api/client/mod.rs
@@ -1818,7 +1818,7 @@ pub mod tests {
             .collect();
         collaborators.sort();
 
-        let expected = ("Jeremy".to_string(), "owner".to_string());
+        let expected = ("Bo".to_string(), "owner".to_string());
 
         assert!(collaborators.contains(&expected));
     }

--- a/src/ps/error.rs
+++ b/src/ps/error.rs
@@ -7,6 +7,7 @@ use std::{fmt, io, num, result};
 use failure::{Backtrace, Context, Fail};
 
 use hyper::http::header::ToStrError;
+use base64_url::base64;
 
 /// Type alias for handling errors throughout the agent
 pub type Result<T> = result::Result<T, Error>;
@@ -255,6 +256,14 @@ impl From<num::ParseIntError> for Error {
 
 impl From<rusoto_core::RusotoError<rusoto_cognito_idp::InitiateAuthError>> for Error {
     fn from(error: rusoto_core::RusotoError<rusoto_cognito_idp::InitiateAuthError>) -> Error {
+        Error::from(Context::new(ErrorKind::InitiateAuthError {
+            error: error.to_string(),
+        }))
+    }
+}
+
+impl From<base64::DecodeError> for Error {
+    fn from(error: base64::DecodeError) -> Error {
         Error::from(Context::new(ErrorKind::InitiateAuthError {
             error: error.to_string(),
         }))

--- a/src/ps/error.rs
+++ b/src/ps/error.rs
@@ -81,7 +81,10 @@ impl Error {
     }
 
     pub fn initiate_auth_error<S: Into<String>>(error: S) -> Error {
-        ErrorKind::InitiateAuthError { error: error.into() }.into()
+        ErrorKind::InitiateAuthError {
+            error: error.into(),
+        }
+        .into()
     }
 }
 

--- a/src/ps/error.rs
+++ b/src/ps/error.rs
@@ -6,8 +6,8 @@ use std::{fmt, io, num, result};
 
 use failure::{Backtrace, Context, Fail};
 
-use hyper::http::header::ToStrError;
 use base64_url::base64;
+use hyper::http::header::ToStrError;
 
 /// Type alias for handling errors throughout the agent
 pub type Result<T> = result::Result<T, Error>;

--- a/src/ps/error.rs
+++ b/src/ps/error.rs
@@ -79,6 +79,10 @@ impl Error {
     pub fn invalid_unicode_path(path: PathBuf) -> Error {
         ErrorKind::InvalidUnicodePath { path }.into()
     }
+
+    pub fn initiate_auth_error<S: Into<String>>(error: S) -> Error {
+        ErrorKind::InitiateAuthError { error: error.into() }.into()
+    }
 }
 
 impl Fail for Error {


### PR DESCRIPTION
## Changes

- Coverts all `unwrap`s in `login` into explicit `Result::Err` values
- Introduces some mocked tests
- Mocked tests only run for the `"mocks"` feature flag

## Concerns


### Unwieldy way to run the mocked tests

I currently run a single test at a time with the `"mocks"` feature enabled. I could refactor the mocked tests into their own `mod` and throw a `cfg(not(feature = "mocks"))` over the original tests.

```
env PENNSIEVE_API_KEY=00000000-0000-0000-0000-000000000000 PENNSIEVE_SECRET_KEY=00000000-0000-0000-0000-000000000000 cargo test mocked_test --features="mocks" -- --test-threads=1
```

Running with the feature `"mocks"` breaks the original tests because of this change

```rust
    fn get_url(&self) -> url::Url {
        #[cfg(feature = "mocks")]
        let url = mockito::server_url().parse::<Url>().unwrap();

        #[cfg(not(feature = "mocks"))]
        let url = self.inner.lock().unwrap().config.env().url().clone();

        url
    }
 ```

### ~~Use of `Either` to get `login` to compile~~

 The early checks on the response from the Pennsieve API `/cognito-config` endpoint differ in that their error type is a `ps::Error` while the return type in the `cognito.initiate_auth(...)` chain is a `MapErr<...>`. I couldn't figure out the right way to get these type to agree so I forced it with the `Either` type.
 
 Early check example:
 ```rust
                 let token_pool_value = match config_response.get("tokenPool") {
                    Some(value) => value,
                    None => return Either::A(futures::failed(crate::ps::Error::initiate_auth_error(
                        "Pennsieve server Cognito config missing token pool.",
                    )))
                };
```

MapErr:

```rust
Either::B(
                    cognito
                        .initiate_auth(request)
                        .map_err(Into::into)
                        ....
```
 
 ### ~~Reptitive error handling pattern~~
 
 All of the checks are some variation of:
 
 ```rust
                 let << var >> = << expression >>  {
                    Some(value) => value,
                    None => return << something that eventually results in Future<Error=ps::Error> >>
                };
 ```

I feel like there must be something akin to the `?` operator that is syntactic sugar for this. Or we could write a macro? (I'd rather avoid writing a macro, however)
